### PR TITLE
De 104 fix retrieving stages in zendesk sell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 config.json
+
+#poetry
+poetry.lock
+pyproject.toml

--- a/tap_zendesk_sell/main.py
+++ b/tap_zendesk_sell/main.py
@@ -229,7 +229,7 @@ def process_stream(
 
                 replication_value = decode_dt(record[replication_key])
 
-                if state and replication_value <= state:
+                if state and replication_value < state:
                     continue
 
                 stream.set_stream_state(

--- a/tap_zendesk_sell/main.py
+++ b/tap_zendesk_sell/main.py
@@ -153,8 +153,7 @@ def process_unordered_streams(stream: Stream, client: ZendeskSell):
             endpoint, order_by=order_by, order_dir=order_dir, per_page=per_page
         )
 
-        if state:
-            record_gen = skip_unordered(record_gen, state, partition_key)
+        record_gen = skip_unordered(record_gen, state, partition_key)
 
         process_stream(
             stream,

--- a/tap_zendesk_sell/stream.py
+++ b/tap_zendesk_sell/stream.py
@@ -64,6 +64,8 @@ def skip_descending(gen: Iterable[Dict], state: datetime, key: str) -> Iterable[
 def skip_unordered(gen: Iterable[Dict], state: datetime, key: str) -> Iterable[Dict]:
     """runs through all the items (it has to, because they have no ordering)
     and sorts and filters them based on the previous state"""
+    if not state:
+        yield from sorted(gen, key=lambda record: decode_dt(record[key]), reverse=False)
     random_list = []
     for record in gen:
         replication_value = decode_dt(record[key])


### PR DESCRIPTION
in `process_stream` function, `state` is constantly overwritten by the replication value of the record. So if the record is not sorted before going into this function, some of the records will be missed. So the changes are:
1. sort the unordered record no matter the state exist or not
2. there exists two different records has the same replication_value, write the record even if the `replication_value=state`.